### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ include_dir  = Marlin
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared> -<src/lcd/extui/lib/mks_ui>
   -<src/lcd/menu> -<src/lcd/dwin> -<src/lcd/extui/lib/dgus> -<src/lcd/extui/lib/ftdi_eve_touch_ui> -<src/lcd/dogm>
 extra_scripts      =
-  pre:buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+  pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
 build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-all-constants
 lib_deps           =


### PR DESCRIPTION
fix platform.io build >= 4.4

_Note: Not verified on < 4.4._

previous fixes were made to the common-dependencies.py file, so it needs to be used to have any effect. Suspect changes to platformio.ini were forgotten

### Description

The build with platform.io > 4.4 still fails, the fixes to buildroot were made to the `common-dependencies.py` which isn't used. Instead the project is configured to use `common-features-dependencies.py`.

The error fixed is

```
ModuleNotFoundError: No module named 'platformio.managers.package':
  [...]
  File "./buildroot/share/PlatformIO/scripts/common-features-dependencies.py", line 12:
    from platformio.managers.package import PackageManager
```

firmware builds ok
