### PR TITLE
Update pins_MKS_ROBIN_NANO.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -225,7 +225,9 @@
 // Heaters / Fans
 //
 #define HEATER_0_PIN                      PC3
-#define HEATER_BED_PIN                    PA0
+#ifndef HEATER_BED_PIN
+  #define HEATER_BED_PIN                    PA0
+#endif
 
 #if HOTENDS == 1                                  
   #ifndef FAN1_PIN


### PR DESCRIPTION
HEATER_BED_PIN definition check

### Requirements

None

### Description

check if HEATED_BED_PIN is already defined

### Benefits

check if HEATED_BED_PIN is already defined

### Related Issues

if HEATED_BED_PIN is defined in configuration.h you'll get redefined messages
